### PR TITLE
Get parameter hierarchy as nested dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage.xml
 .pytest_cache
 .python-version
 .venv
+venv/
 .idea/
 
 /build/

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ assert parameter == {
 }
 ```
 
-Get a multiple parameters
--------------------------
+Get multiple parameters
+-----------------------
 
 ``` python
 parameters = store.get_parameters(['param1', 'param2'])
@@ -130,6 +130,44 @@ assert parameters == {
     '/dev/db/postgres_password': 'dev_password'
 }
 ```
+
+Get parameters with original hierarchy
+--------------------------------------
+You can also get parameters by path, but in a nested structure that models the path hierarchy.
+
+``` python
+parameters = store.get_parameters_with_hierarchy('/dev/')
+
+assert parameters == {
+    'app': {
+        'secret': 'dev_secret',
+    },
+    'db': {
+        'postgres_username': 'dev_username',
+        'postgres_password': 'dev_password',
+    },
+}
+```
+
+By default `get_parameters_with_hierarchy` strips the leading path component. To return the selected parameters
+with the full hierarchy, set `strip_path` to `False`.
+
+``` python
+parameters = store.get_parameters_with_hierarchy('/dev/', strip_path=False)
+
+assert parameters == {
+    'dev': {
+        'app': {
+            'secret': 'dev_secret',
+        },
+        'db': {
+            'postgres_username': 'dev_username',
+            'postgres_password': 'dev_password',
+        },
+    },
+}
+```
+
 
 Populating Environment Variables
 ================================

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -6,7 +6,15 @@ from ssm_parameter_store import EC2ParameterStore
 
 
 @pytest.fixture
-def parameter_store():
+def fake_ssm():
+    """Provide a consistent faked SSM context for running an entire test case."""
+    with mock_ssm():
+        yield None
+
+
+@pytest.fixture
+def parameter_store(fake_ssm):
+    """An SSM parameter store with a well-known set of fake test data"""
     # Load test parameters
     ssm = boto3.client('ssm')
     ssm.put_parameter(Name='key', Value='hello', Type='SecureString')
@@ -20,47 +28,39 @@ def parameter_store():
     return EC2ParameterStore()
 
 
-@mock_ssm
-def test_extract_parameter_returns_key_pair_tuple():
-    store = parameter_store()
+def test_extract_parameter_returns_key_pair_tuple(parameter_store):
     parameter = {
         'Name': 'key',
         'Value': 'hello'
     }
-    extracted_parameter = store.extract_parameter(parameter)
+    extracted_parameter = parameter_store.extract_parameter(parameter)
     assert isinstance(extracted_parameter, tuple)
     assert extracted_parameter[0] == 'key'
     assert extracted_parameter[1] == 'hello'
 
 
-@mock_ssm
-def test_get_paginated_parameters():
+def test_get_paginated_parameters(parameter_store):
     """ SSM returns a maximum of 10 parameters per response
         - additional keys can be requested by passing
         NextToken in subsequent requests.
     """
-    store = parameter_store()
     client_kwargs = dict(Path='/test/path/')
-    parameter_keys = store._get_paginated_parameters(
+    parameter_keys = parameter_store._get_paginated_parameters(
         client_method=boto3.client('ssm').get_parameters_by_path,
         **client_kwargs
     )
     assert len(parameter_keys) == 20
 
 
-@mock_ssm
-def test_get_parameter():
-    store = parameter_store()
-    parameter_keys = store.get_parameter('key')
+def test_get_parameter(parameter_store):
+    parameter_keys = parameter_store.get_parameter('key')
     assert len(parameter_keys) == 1
     assert 'key' in parameter_keys.keys()
     assert parameter_keys.get('key') == 'hello'
 
 
-@mock_ssm
-def test_get_parameters():
-    store = parameter_store()
-    parameter_keys = store.get_parameters(['key', 'second-key'])
+def test_get_parameters(parameter_store):
+    parameter_keys = parameter_store.get_parameters(['key', 'second-key'])
     assert len(parameter_keys) == 2
     assert 'key' in parameter_keys.keys()
     assert 'second-key' in parameter_keys.keys()
@@ -68,36 +68,27 @@ def test_get_parameters():
     assert parameter_keys.get('second-key') == 'world'
 
 
-@mock_ssm
-def test_get_parameters_by_path():
-    store = parameter_store()
-    parameter_keys = store.get_parameters_by_path('/path/to/another/key/')
+def test_get_parameters_by_path(parameter_store):
+    parameter_keys = parameter_store.get_parameters_by_path('/path/to/another/key/')
     assert len(parameter_keys) == 1
 
 
-@mock_ssm
-def test_get_parameters_by_path_with_recursion():
-    store = parameter_store()
-    parameter_keys = store.get_parameters_by_path('/path/to/', recursive=True)
+def test_get_parameters_by_path_with_recursion(parameter_store):
+    parameter_keys = parameter_store.get_parameters_by_path('/path/to/', recursive=True)
     assert len(parameter_keys) == 3
 
 
-@mock_ssm
-def test_get_parameters_by_path_without_recursion():
-    store = parameter_store()
-    parameter_keys = store.get_parameters_by_path('/path/to/', recursive=False)
+def test_get_parameters_by_path_without_recursion(parameter_store):
+    parameter_keys = parameter_store.get_parameters_by_path('/path/to/', recursive=False)
     assert len(parameter_keys) == 2
 
 
-@mock_ssm
-def test_stripping_path_in_parameter():
-    store = parameter_store()
-    parameter_keys = store.get_parameter('/path/to/third-key', strip_path=False)
+def test_stripping_path_in_parameter(parameter_store):
+    parameter_keys = parameter_store.get_parameter('/path/to/third-key', strip_path=False)
     assert parameter_keys.get('/path/to/third-key')
 
-    stripped_parameter_keys = store.get_parameter('/path/to/third-key', strip_path=True)
+    stripped_parameter_keys = parameter_store.get_parameter('/path/to/third-key', strip_path=True)
     assert stripped_parameter_keys.get('third-key')
 
-    stripped_parameter_keys = store.get_parameter('key', strip_path=True)
+    stripped_parameter_keys = parameter_store.get_parameter('key', strip_path=True)
     assert stripped_parameter_keys.get('key')
-

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -92,3 +92,37 @@ def test_stripping_path_in_parameter(parameter_store):
 
     stripped_parameter_keys = parameter_store.get_parameter('key', strip_path=True)
     assert stripped_parameter_keys.get('key')
+
+
+def test_get_parameters_with_hierarchy(parameter_store):
+    expected_result = {
+        'third-key': 'danger',
+        'fourth-key': 'will',
+        'another': {
+            'key': {
+                'fifth-key': 'robinson',
+            },
+        },
+    }
+
+    parameter_keys = parameter_store.get_parameters_with_hierarchy('/path/to', strip_path=True)
+    assert parameter_keys == expected_result
+
+    parameter_keys = parameter_store.get_parameters_with_hierarchy('/path/to', strip_path=False)
+    assert parameter_keys == {
+        'path': {
+            'to': expected_result,
+        },
+    }
+
+
+def test_get_parameters_with_hierarchy_for_path_with_no_nesting(parameter_store):
+    parameter_keys = parameter_store.get_parameters_with_hierarchy('/path/to/another/key/', strip_path=True)
+
+    assert len(parameter_keys) == 1
+    assert parameter_keys.get('fifth-key')
+
+
+def test_get_parameters_with_hierarchy_for_nonexistent_path(parameter_store):
+    parameter_keys = parameter_store.get_parameters_with_hierarchy('/does/not/exist', strip_path=True)
+    assert len(parameter_keys) == 0


### PR DESCRIPTION
New function to recursively fetch parameters as a nested dictionary (not flattened like `get_parameters_by_path`)

Also:
* Supporting test cases
* Update documentation
* Clean up existing tests