### PR TITLE
parse StringList

### DIFF
--- a/src/ssm_parameter_store/stores.py
+++ b/src/ssm_parameter_store/stores.py
@@ -34,6 +34,8 @@ class EC2ParameterStore:
             key_parts = key.split(self.path_delimiter)
             key = key_parts[-1]
         value = parameter['Value']
+        if parameter['Type'] == 'StringList':
+            value = value.split(',')
         return (key, value)
 
     def get_parameter(self, name, decrypt=True, strip_path=True):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -19,6 +19,7 @@ def parameter_store(fake_ssm):
     ssm = boto3.client('ssm')
     ssm.put_parameter(Name='key', Value='hello', Type='SecureString')
     ssm.put_parameter(Name='second-key', Value='world', Type='String')
+    ssm.put_parameter(Name='list-key', Value='hello,world', Type='StringList')
     ssm.put_parameter(Name='/path/to/third-key', Value='danger', Type='SecureString')
     ssm.put_parameter(Name='/path/to/fourth-key', Value='will', Type='SecureString')
     ssm.put_parameter(Name='/path/to/another/key/fifth-key', Value='robinson', Type='String')
@@ -60,12 +61,14 @@ def test_get_parameter(parameter_store):
 
 
 def test_get_parameters(parameter_store):
-    parameter_keys = parameter_store.get_parameters(['key', 'second-key'])
-    assert len(parameter_keys) == 2
+    parameter_keys = parameter_store.get_parameters(['key', 'second-key', 'list-key'])
+    assert len(parameter_keys) == 3
     assert 'key' in parameter_keys.keys()
     assert 'second-key' in parameter_keys.keys()
+    assert 'list-key' in parameter_keys.keys()
     assert parameter_keys.get('key') == 'hello'
     assert parameter_keys.get('second-key') == 'world'
+    assert parameter_keys.get('list-key') == ['hello', 'world']
 
 
 def test_get_parameters_by_path(parameter_store):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -32,7 +32,8 @@ def parameter_store(fake_ssm):
 def test_extract_parameter_returns_key_pair_tuple(parameter_store):
     parameter = {
         'Name': 'key',
-        'Value': 'hello'
+        'Value': 'hello',
+        'Type': 'SecureString'
     }
     extracted_parameter = parameter_store.extract_parameter(parameter)
     assert isinstance(extracted_parameter, tuple)


### PR DESCRIPTION
as stated in AWS docs, the StringList is always comma separated list of strings.
regarding this, in this PR, I just split the string using the comma.